### PR TITLE
Add optional padding byte parameter to !align

### DIFF
--- a/write_asm.c
+++ b/write_asm.c
@@ -1912,7 +1912,7 @@ static LONG_PTR ParseAlignSpecialCommand(TCHAR *lpText, LONG_PTR nArgsOffset, DW
 		if(dwPaddingByteValue > 0xFF)
 		{
 			lstrcpy(lpError, _T("Out of range error, byte value expected"));
-			return -(p - lpText);
+			return -(p-lpText);
 		}
 
 		*pbPaddingByteValue = (BYTE)dwPaddingByteValue;

--- a/write_asm.c
+++ b/write_asm.c
@@ -1870,10 +1870,10 @@ static LONG_PTR ParseSpecialCommand(TCHAR *lpText, UINT *pnSpecialCmd, TCHAR *lp
 	return p-lpText;
 }
 
-static LONG_PTR ParseAlignSpecialCommand(TCHAR* lpText, LONG_PTR nArgsOffset, DWORD_PTR dwAddress, DWORD_PTR* pdwPaddingSize, BYTE* pbPaddingByteValue, TCHAR* lpError)
+static LONG_PTR ParseAlignSpecialCommand(TCHAR *lpText, LONG_PTR nArgsOffset, DWORD_PTR dwAddress, DWORD_PTR *pdwPaddingSize, BYTE *pbPaddingByteValue, TCHAR *lpError)
 {
-	TCHAR* p;
-	TCHAR* pAfterWhiteSpace;
+	TCHAR *p;
+	TCHAR *pAfterWhiteSpace;
 	DWORD_PTR dwAlignValue;
 	DWORD_PTR dwPaddingSize;
 	LONG_PTR result;
@@ -1883,34 +1883,33 @@ static LONG_PTR ParseAlignSpecialCommand(TCHAR* lpText, LONG_PTR nArgsOffset, DW
 	*pbPaddingByteValue = 0;
 
 	pAfterWhiteSpace = SkipSpaces(p);
-	if (pAfterWhiteSpace == p)
+	if(pAfterWhiteSpace == p)
 	{
 		lstrcpy(lpError, _T("Could not parse command, whitespace expected"));
-		return -(p - lpText);
+		return -(p-lpText);
 	}
 
 	p = pAfterWhiteSpace;
 
 	result = ParseDWORDPtr(p, &dwAlignValue, lpError);
-	if (result <= 0)
-		return -(p - lpText) + result;
+	if(result <= 0)
+		return -(p-lpText)+result;
 
-	if (!GetAlignPaddingSize(dwAddress, dwAlignValue, &dwPaddingSize, lpError))
-		return -(p - lpText);
+	if(!GetAlignPaddingSize(dwAddress, dwAlignValue, &dwPaddingSize, lpError))
+		return -(p-lpText);
 
 	p += result;
 	p = SkipSpaces(p);
 
-	// Optional padding byte
-	if (*p != _T('\0') && *p != _T(';'))
+	if(*p != '\0' && *p != ';')
 	{
 		DWORD_PTR dwPaddingByteValue;
 
 		result = ParseDWORDPtr(p, &dwPaddingByteValue, lpError);
-		if (result <= 0)
+		if(result <= 0)
 			return -(p - lpText) + result;
 
-		if (dwPaddingByteValue > 0xFF)
+		if(dwPaddingByteValue > 0xFF)
 		{
 			lstrcpy(lpError, _T("Out of range error, byte value expected"));
 			return -(p - lpText);
@@ -1921,16 +1920,16 @@ static LONG_PTR ParseAlignSpecialCommand(TCHAR* lpText, LONG_PTR nArgsOffset, DW
 		p += result;
 		p = SkipSpaces(p);
 
-		if (*p != _T('\0') && *p != _T(';'))
+		if(*p != '\0' && *p != ';')
 		{
 			lstrcpy(lpError, _T("Unexpected input after end of command"));
-			return -(p - lpText);
+			return -(p-lpText);
 		}
 	}
 
 	*pdwPaddingSize = dwPaddingSize;
 
-	return p - lpText;
+	return p-lpText;
 }
 
 static LONG_PTR ParsePadSpecialCommand(TCHAR *lpText, LONG_PTR nArgsOffset, BYTE *pbPaddingByteValue, TCHAR *lpError)

--- a/write_asm.c
+++ b/write_asm.c
@@ -1907,7 +1907,7 @@ static LONG_PTR ParseAlignSpecialCommand(TCHAR *lpText, LONG_PTR nArgsOffset, DW
 
 		result = ParseDWORDPtr(p, &dwPaddingByteValue, lpError);
 		if(result <= 0)
-			return -(p-lpText) + result;
+			return -(p-lpText)+result;
 
 		if(dwPaddingByteValue > 0xFF)
 		{

--- a/write_asm.c
+++ b/write_asm.c
@@ -1907,7 +1907,7 @@ static LONG_PTR ParseAlignSpecialCommand(TCHAR *lpText, LONG_PTR nArgsOffset, DW
 
 		result = ParseDWORDPtr(p, &dwPaddingByteValue, lpError);
 		if(result <= 0)
-			return -(p - lpText) + result;
+			return -(p-lpText) + result;
 
 		if(dwPaddingByteValue > 0xFF)
 		{

--- a/write_asm.c
+++ b/write_asm.c
@@ -179,13 +179,13 @@ static LONG_PTR SpecialCommandToData(CMD_BLOCK_NODE *cmd_block_node, DWORD_PTR *
 	switch(nSpecialCmd)
 	{
 	case SPECIAL_CMD_ALIGN:
-		result = ParseAlignSpecialCommand(lpText, result, dwAddress, &dwPaddingSize, lpError);
+		result = ParseAlignSpecialCommand(lpText, result, dwAddress, &dwPaddingSize, &bPaddingByteValue, lpError);
 		if(result <= 0)
 			return result;
 
 		if(dwPaddingSize > 0)
 		{
-			if(!InsertBytes(lpText, dwPaddingSize, 0, &cmd_block_node->cmd_head, lpError))
+			if(!InsertBytes(lpText, dwPaddingSize, bPaddingByteValue, &cmd_block_node->cmd_head, lpError))
 				return 0;
 
 			cmd_block_node->nSize += dwPaddingSize;
@@ -1870,44 +1870,67 @@ static LONG_PTR ParseSpecialCommand(TCHAR *lpText, UINT *pnSpecialCmd, TCHAR *lp
 	return p-lpText;
 }
 
-static LONG_PTR ParseAlignSpecialCommand(TCHAR *lpText, LONG_PTR nArgsOffset, DWORD_PTR dwAddress, DWORD_PTR *pdwPaddingSize, TCHAR *lpError)
+static LONG_PTR ParseAlignSpecialCommand(TCHAR* lpText, LONG_PTR nArgsOffset, DWORD_PTR dwAddress, DWORD_PTR* pdwPaddingSize, BYTE* pbPaddingByteValue, TCHAR* lpError)
 {
-	TCHAR *p;
-	TCHAR *pAfterWhiteSpace;
+	TCHAR* p;
+	TCHAR* pAfterWhiteSpace;
 	DWORD_PTR dwAlignValue;
 	DWORD_PTR dwPaddingSize;
 	LONG_PTR result;
 
 	p = lpText + nArgsOffset;
 
+	*pbPaddingByteValue = 0;
+
 	pAfterWhiteSpace = SkipSpaces(p);
-	if(pAfterWhiteSpace == p)
+	if (pAfterWhiteSpace == p)
 	{
 		lstrcpy(lpError, _T("Could not parse command, whitespace expected"));
-		return -(p-lpText);
+		return -(p - lpText);
 	}
 
 	p = pAfterWhiteSpace;
 
 	result = ParseDWORDPtr(p, &dwAlignValue, lpError);
-	if(result <= 0)
-		return -(p-lpText)+result;
+	if (result <= 0)
+		return -(p - lpText) + result;
 
-	if(!GetAlignPaddingSize(dwAddress, dwAlignValue, &dwPaddingSize, lpError))
-		return -(p-lpText);
+	if (!GetAlignPaddingSize(dwAddress, dwAlignValue, &dwPaddingSize, lpError))
+		return -(p - lpText);
 
 	p += result;
 	p = SkipSpaces(p);
 
-	if(*p != '\0' && *p != ';')
+	// Optional padding byte
+	if (*p != _T('\0') && *p != _T(';'))
 	{
-		lstrcpy(lpError, _T("Unexpected input after end of command"));
-		return -(p-lpText);
+		DWORD_PTR dwPaddingByteValue;
+
+		result = ParseDWORDPtr(p, &dwPaddingByteValue, lpError);
+		if (result <= 0)
+			return -(p - lpText) + result;
+
+		if (dwPaddingByteValue > 0xFF)
+		{
+			lstrcpy(lpError, _T("Out of range error, byte value expected"));
+			return -(p - lpText);
+		}
+
+		*pbPaddingByteValue = (BYTE)dwPaddingByteValue;
+
+		p += result;
+		p = SkipSpaces(p);
+
+		if (*p != _T('\0') && *p != _T(';'))
+		{
+			lstrcpy(lpError, _T("Unexpected input after end of command"));
+			return -(p - lpText);
+		}
 	}
 
 	*pdwPaddingSize = dwPaddingSize;
 
-	return p-lpText;
+	return p - lpText;
 }
 
 static LONG_PTR ParsePadSpecialCommand(TCHAR *lpText, LONG_PTR nArgsOffset, BYTE *pbPaddingByteValue, TCHAR *lpError)

--- a/write_asm.h
+++ b/write_asm.h
@@ -88,7 +88,7 @@ static LONG_PTR ParseCommand(TCHAR *lpText, DWORD_PTR dwAddress, DWORD_PTR dwBas
 static LONG_PTR ResolveCommand(TCHAR *lpCommand, DWORD_PTR dwBaseAddress, TCHAR **ppNewCommand, TCHAR **ppComment, TCHAR *lpError);
 static LONG_PTR ReplaceLabelsWithFooAddress(TCHAR *lpCommand, DWORD_PTR dwCommandAddress, UINT nDeltaSize, TCHAR **ppNewCommand, TCHAR *lpError);
 static LONG_PTR ParseSpecialCommand(TCHAR *lpText, UINT *pnSpecialCmd, TCHAR *lpError);
-static LONG_PTR ParseAlignSpecialCommand(TCHAR *lpText, LONG_PTR nArgsOffset, DWORD_PTR dwAddress, DWORD_PTR *pdwPaddingSize, BYTE* pbPaddingByteValue, TCHAR *lpError);
+static LONG_PTR ParseAlignSpecialCommand(TCHAR *lpText, LONG_PTR nArgsOffset, DWORD_PTR dwAddress, DWORD_PTR *pdwPaddingSize, BYTE *pbPaddingByteValue, TCHAR *lpError);
 static LONG_PTR ParsePadSpecialCommand(TCHAR *lpText, LONG_PTR nArgsOffset, BYTE *pbPaddingByteValue, TCHAR *lpError);
 static BOOL GetAlignPaddingSize(DWORD_PTR dwAddress, DWORD_PTR dwAlignValue, DWORD_PTR *pdwPaddingSize, TCHAR *lpError);
 static BOOL InsertBytes(TCHAR *lpText, SIZE_T nBytesCount, BYTE bByteValue, CMD_HEAD *p_cmd_head, TCHAR *lpError);

--- a/write_asm.h
+++ b/write_asm.h
@@ -88,7 +88,7 @@ static LONG_PTR ParseCommand(TCHAR *lpText, DWORD_PTR dwAddress, DWORD_PTR dwBas
 static LONG_PTR ResolveCommand(TCHAR *lpCommand, DWORD_PTR dwBaseAddress, TCHAR **ppNewCommand, TCHAR **ppComment, TCHAR *lpError);
 static LONG_PTR ReplaceLabelsWithFooAddress(TCHAR *lpCommand, DWORD_PTR dwCommandAddress, UINT nDeltaSize, TCHAR **ppNewCommand, TCHAR *lpError);
 static LONG_PTR ParseSpecialCommand(TCHAR *lpText, UINT *pnSpecialCmd, TCHAR *lpError);
-static LONG_PTR ParseAlignSpecialCommand(TCHAR *lpText, LONG_PTR nArgsOffset, DWORD_PTR dwAddress, DWORD_PTR *pdwPaddingSize, TCHAR *lpError);
+static LONG_PTR ParseAlignSpecialCommand(TCHAR *lpText, LONG_PTR nArgsOffset, DWORD_PTR dwAddress, DWORD_PTR *pdwPaddingSize, BYTE* pbPaddingByteValue, TCHAR *lpError);
 static LONG_PTR ParsePadSpecialCommand(TCHAR *lpText, LONG_PTR nArgsOffset, BYTE *pbPaddingByteValue, TCHAR *lpError);
 static BOOL GetAlignPaddingSize(DWORD_PTR dwAddress, DWORD_PTR dwAlignValue, DWORD_PTR *pdwPaddingSize, TCHAR *lpError);
 static BOOL InsertBytes(TCHAR *lpText, SIZE_T nBytesCount, BYTE bByteValue, CMD_HEAD *p_cmd_head, TCHAR *lpError);


### PR DESCRIPTION
This PR adds support for an optional fill byte parameter to the !align special command.

Examples:

!align 10
!align 10 CC
!align 10 90
!align 10 C3

The original syntax remains fully compatible and continues to use 00 padding by default.

The implementation reuses the existing padding-byte logic already used by !pad.

Tested successfully in both x32dbg and x64dbg.